### PR TITLE
Add clean target to `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ $(foreach element,$(CHARTS),$(eval $(call make-chart-target,$(element))))
 $(BUILDDIR):
 	mkdir -p $(BUILDDIR)
 
+.PHONY: clean
+clean:
+	rm -rf $(BUILDDIR)
+
 .PHONY: lint
 lint: $(RELEASE_FILES) 
 	replicated release lint --yaml-dir $(BUILDDIR)


### PR DESCRIPTION
TL;DR
-----

Makes it easier to clean the build directory

Details
-------

Adds a new `clean` target to the `Makefile` that removes the contents
of the build directory.

