### PR TITLE
Fixes misalignment with other charts

### DIFF
--- a/charts/providerconfigs/Chart.yaml
+++ b/charts/providerconfigs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: providerconfigs
 description: A Helm chart for configuring Crossplane providers with AWS and Kubernetes credentials
 type: application
-version: 0.2.1  # Bumped from 0.2.0 to 0.2.1
+version: 0.2.2  # Bumped from 0.2.1 to 0.2.2
 appVersion: "1.0.0"

--- a/charts/providerconfigs/templates/_helpers.tpl
+++ b/charts/providerconfigs/templates/_helpers.tpl
@@ -80,7 +80,7 @@ Get the credentials secret key
 {{/*
 Common annotations
 */}}
-{{- define "providerconfigs.commonAnnotations" -}}
+{{- define "providerconfigs.annotations" -}}
 {{- if .Values.commonAnnotations }}
 {{- range $key, $value := .Values.commonAnnotations }}
 {{ $key }}: {{ $value | quote }}

--- a/charts/providerconfigs/templates/_helpers.tpl
+++ b/charts/providerconfigs/templates/_helpers.tpl
@@ -40,6 +40,11 @@ helm.sh/chart: {{ include "providerconfigs.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels }}
+{{- range $key, $value := .Values.commonLabels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -71,16 +76,6 @@ Get the credentials secret key
 {{- "creds" }}
 {{- end }}
 
-{{/*
-Common labels
-*/}}
-{{- define "providerconfigs.commonLabels" -}}
-{{- if .Values.commonLabels }}
-{{- range $key, $value := .Values.commonLabels }}
-{{ $key }}: {{ $value | quote }}
-{{- end }}
-{{- end }}
-{{- end }}
 
 {{/*
 Common annotations

--- a/charts/providerconfigs/templates/aws.yaml
+++ b/charts/providerconfigs/templates/aws.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ .Values.aws.providerConfigName }}
   labels:
     {{- include "providerconfigs.labels" . | nindent 4 }}
-    {{- include "providerconfigs.commonLabels" . | nindent 4 }}
   annotations:
     {{- include "providerconfigs.commonAnnotations" . | nindent 4 }}
 spec:

--- a/charts/providerconfigs/templates/aws.yaml
+++ b/charts/providerconfigs/templates/aws.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "providerconfigs.labels" . | nindent 4 }}
   annotations:
-    {{- include "providerconfigs.commonAnnotations" . | nindent 4 }}
+    {{- include "providerconfigs.annotations" . | nindent 4 }}
 spec:
   credentials:
     source: {{ .Values.aws.authentication.method | title }}

--- a/charts/providerconfigs/templates/kubernetes.yaml
+++ b/charts/providerconfigs/templates/kubernetes.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ .Values.kubernetes.providerConfigName }}
   labels:
     {{- include "providerconfigs.labels" . | nindent 4 }}
-    {{- include "providerconfigs.commonLabels" . | nindent 4 }}
   annotations:
     {{- include "providerconfigs.commonAnnotations" . | nindent 4 }}
 spec:

--- a/charts/providerconfigs/templates/kubernetes.yaml
+++ b/charts/providerconfigs/templates/kubernetes.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "providerconfigs.labels" . | nindent 4 }}
   annotations:
-    {{- include "providerconfigs.commonAnnotations" . | nindent 4 }}
+    {{- include "providerconfigs.annotations" . | nindent 4 }}
 spec:
   credentials:
     source: {{ .Values.kubernetes.authentication.source }}

--- a/charts/providerconfigs/templates/secret.yaml
+++ b/charts/providerconfigs/templates/secret.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ include "providerconfigs.secretNamespace" . }}
   labels:
     {{- include "providerconfigs.labels" . | nindent 4 }}
-    {{- include "providerconfigs.commonLabels" . | nindent 4 }}
   annotations:
     {{- include "providerconfigs.commonAnnotations" . | nindent 4 }}
 type: Opaque

--- a/charts/providerconfigs/templates/secret.yaml
+++ b/charts/providerconfigs/templates/secret.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "providerconfigs.labels" . | nindent 4 }}
   annotations:
-    {{- include "providerconfigs.commonAnnotations" . | nindent 4 }}
+    {{- include "providerconfigs.annotations" . | nindent 4 }}
 type: Opaque
 stringData:
   {{ include "providerconfigs.secretKey" . }}: |


### PR DESCRIPTION
TL;DR
-----

Aligns label and annotation handling in `providerconfigs` chart with ever
other chart and expected conventions.

Details
-------

Makes several improvements to the Provider Configurations chart to
enhance consistency and maintainability:

 1. Standardizes Label and Annotation Handling
    * Consolidates the label handling into a single helper function that
      includes both standard Helm labels and custom labels from
      .Values.commonLabels
    * Renames the annotations helper from providerconfigs.commonAnnotations to
      providerconfigs.annotations for consistency with the labels approach
 2. Version Update
    * Bumped the chart version from 0.2.1 to 0.2.2 to reflect these
      maintenance improvements


#### Impact

These changes improve the chart's maintainability and consistency without changing its functionality:

 * Simplifies Template Code: Templates now use a single include for labels,
   making them cleaner and easier to maintain
 * Applies Consistent Naming Convention: Both labels and annotations helpers
   now follow the same naming pattern
 * Makes No Functional Changes: The actual behavior and output of the chart
   remains the same

These improvements align with best practices for Helm chart development by
reducing duplication and establishing consistent naming conventions.
