### PR TITLE
Releases the frontend chart with Replicated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ $(eval CHART_$(1)_VERSION := $(shell yq .version $(CHARTDIR)/$(1)/Chart.yaml))
 endef
 $(foreach chart,$(CHARTS),$(eval $(call cache-chart-version,$(chart))))
 
-VERSION     ?= $(CHART_cloud-resources_VERSION)
+VERSION     ?= $(CHART_serverless-pdf-chat_VERSION)
 CHANNEL     := $(shell git branch --show-current)
 ifeq ($(CHANNEL), main)
 	CHANNEL=Unstable

--- a/charts/compositions/Chart.yaml
+++ b/charts/compositions/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: compositions
 description: A Helm chart for Crossplane Composite Resource Definitions and Compositions
 type: application
-version: 0.3.0
-appVersion: "1.0.0"
+version: 0.3.1
+appVersion: "1.0.20"

--- a/charts/compositions/values.yaml
+++ b/charts/compositions/values.yaml
@@ -1,4 +1,7 @@
 # Default values for compositions chart
+global:
+  images:
+    registry: ""
 
 # AWS configuration
 aws:

--- a/charts/providerconfigs/Chart.yaml
+++ b/charts/providerconfigs/Chart.yaml
@@ -3,4 +3,4 @@ name: providerconfigs
 description: A Helm chart for configuring Crossplane providers with AWS and Kubernetes credentials
 type: application
 version: 0.2.2  # Bumped from 0.2.1 to 0.2.2
-appVersion: "1.0.0"
+appVersion: "1.0.20"

--- a/charts/serverless-pdf-chat/Chart.yaml
+++ b/charts/serverless-pdf-chat/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: serverless-pdf-chat
 description: A Helm chart for deploying serverless PDF chat infrastructure
 type: application
-version: 0.13.29  # Bumped from 0.13.25 to 0.13.26
+version: 0.13.30  # Bumped from 0.13.29 to 0.13.30
 appVersion: "1.0.20"  # Bumping from 1.0.16 to 1.0.17

--- a/charts/serverless-pdf-chat/Chart.yaml
+++ b/charts/serverless-pdf-chat/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: serverless-pdf-chat
 description: A Helm chart for deploying serverless PDF chat infrastructure
 type: application
-version: 0.13.31  # Bumped from 0.13.30 to 0.13.31
+version: 0.13.32  # Bumped from 0.13.31 to 0.13.32
 appVersion: "1.0.20"  # Bumping from 1.0.16 to 1.0.17

--- a/charts/serverless-pdf-chat/Chart.yaml
+++ b/charts/serverless-pdf-chat/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: serverless-pdf-chat
 description: A Helm chart for deploying serverless PDF chat infrastructure
 type: application
-version: 0.13.27  # Bumped from 0.13.25 to 0.13.26
+version: 0.13.29  # Bumped from 0.13.25 to 0.13.26
 appVersion: "1.0.20"  # Bumping from 1.0.16 to 1.0.17

--- a/charts/serverless-pdf-chat/Chart.yaml
+++ b/charts/serverless-pdf-chat/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: serverless-pdf-chat
 description: A Helm chart for deploying serverless PDF chat infrastructure
 type: application
-version: 0.13.30  # Bumped from 0.13.29 to 0.13.30
+version: 0.13.31  # Bumped from 0.13.30 to 0.13.31
 appVersion: "1.0.20"  # Bumping from 1.0.16 to 1.0.17

--- a/charts/serverless-pdf-chat/templates/_helpers.tpl
+++ b/charts/serverless-pdf-chat/templates/_helpers.tpl
@@ -133,7 +133,7 @@ Generate the SQS embedding queue name
 Generate the frontend registry
 */}}
 {{- define "serverless-pdf-chat.frontendRegistry" -}}
-{{- $registry := .Values.frontend.image.registry | default (printf "%s.dkr.ecr.%s.amazonaws.com" .Values.aws.accountId .Values.aws.region) -}}
+{{- $registry := .Values.global.images.registry | default .Values.frontend.image.registry | default (printf "%s.dkr.ecr.%s.amazonaws.com" .Values.aws.accountId .Values.aws.region) -}}
 {{- $registry -}}
 {{- end -}}
 

--- a/charts/serverless-pdf-chat/templates/frontend/deployment.yaml
+++ b/charts/serverless-pdf-chat/templates/frontend/deployment.yaml
@@ -27,9 +27,21 @@ spec:
       {{- if .Values.aws.ecrAccessToken }}
       imagePullSecrets:
         - name: {{ include "serverless-pdf-chat.fullname" . }}-ecr-credentials
+      {{- else if .Values.global.images.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.images.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
       {{- else if .Values.frontend.image.pullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- range .Values.frontend.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- else if .Values.frontend.builderImage.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.frontend.builderImage.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.frontend.podSecurityContext | nindent 8 }}

--- a/charts/serverless-pdf-chat/templates/frontend/deployment.yaml
+++ b/charts/serverless-pdf-chat/templates/frontend/deployment.yaml
@@ -25,8 +25,25 @@ spec:
         app.kubernetes.io/component: frontend
     spec:
       {{- if .Values.aws.ecrAccessToken }}
+      {{- if eq (include "serverless-pdf-chat.frontendRegistry" .) (printf "%s.dkr.ecr.%s.amazonaws.com" .Values.aws.accountId .Values.aws.region) }}
       imagePullSecrets:
         - name: {{ include "serverless-pdf-chat.fullname" . }}-ecr-credentials
+      {{- else if .Values.global.images.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.images.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- else if .Values.frontend.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.frontend.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- else if .Values.frontend.builderImage.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.frontend.builderImage.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       {{- else if .Values.global.images.pullSecrets }}
       imagePullSecrets:
         {{- range .Values.global.images.pullSecrets }}

--- a/charts/serverless-pdf-chat/values.schema.json
+++ b/charts/serverless-pdf-chat/values.schema.json
@@ -15,6 +15,23 @@
           "type": "string",
           "description": "Environment name (dev, staging, prod, etc.)",
           "default": "dev"
+        },
+        "images": {
+          "type": "object",
+          "properties": {
+            "registry": {
+              "type": ["string", "null"],
+              "description": "Global registry for all images"
+            },
+            "pullSecrets": {
+              "type": "array",
+              "description": "Global list of image pull secret names",
+              "default": [],
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },
@@ -638,6 +655,14 @@
               "description": "Image pull policy",
               "default": "IfNotPresent",
               "enum": ["Always", "IfNotPresent", "Never"]
+            },
+            "pullSecrets": {
+              "type": "array",
+              "description": "List of existing image pull secret names for builder image",
+              "default": [],
+              "items": {
+                "type": "string"
+              }
             }
           }
         },

--- a/charts/serverless-pdf-chat/values.yaml
+++ b/charts/serverless-pdf-chat/values.yaml
@@ -4,6 +4,8 @@
 global:
   namePrefix: "pdf-chat"
   environment: "dev"
+  images:
+    registry: ""
 
 images:
   repository: "serverless-pdf-chat"  # Repository name in ECR

--- a/charts/serverless-pdf-chat/values.yaml
+++ b/charts/serverless-pdf-chat/values.yaml
@@ -6,6 +6,7 @@ global:
   environment: "dev"
   images:
     registry: ""
+    pullSecrets: []  # Global list of image pull secret names
 
 images:
   repository: "serverless-pdf-chat"  # Repository name in ECR

--- a/replicated/compositions-chart.yaml
+++ b/replicated/compositions-chart.yaml
@@ -1,12 +1,13 @@
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
-  name: cloud-providers
+  name: compositions
 spec:
   # chart identifies a matching chart from a .tgz
   chart:
     name: compositions
-    chartVersion: 0.3.0
+    chartVersion: 0.3.1
+  namespace: serverless-pdf-chat
   weight: -10
 
   helmUpgradeFlags:

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -9,7 +9,7 @@ spec:
       title: AWS Configuration
       description: |
       items:
-        - name: 
+        - name: aws_account_id
           title: AWS Account ID
           help_text: >
             The AWS account ID for backend resources
@@ -17,7 +17,7 @@ spec:
           required: true
           validation:
             regex:
-              pattern: ^\d{12}$
+              pattern: '^\d{12}$'
               message: Please enter your 12-digit AWS account ID. You can find your account ID in the AWS Management Console.
         - name: aws_region
           title: AWS Region

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -9,10 +9,21 @@ spec:
       title: AWS Configuration
       description: |
       items:
+        - name: 
+          title: AWS Account ID
+          help_text: >
+            The AWS account ID for backend resources
+          type: text
+          required: true
+          validation:
+            regex:
+              # update this regex for the format of AWS account IDs (currently it's a copy paste of one that validates hostnames that I've left here for syntax purposes) - AI!
+              pattern: ^(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*\.[A-Za-z]{2,}$
+              message: Please enter the account ID for your AWS account. You can find your account ID in the AWS Management Console.
         - name: aws_region
           title: AWS Region
           help_text: >
-            Select the AWS region to use
+            Select the AWS region to use for the backend
           type: dropdown
           required: true
           default: us-east-1

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -17,9 +17,8 @@ spec:
           required: true
           validation:
             regex:
-              # update this regex for the format of AWS account IDs (currently it's a copy paste of one that validates hostnames that I've left here for syntax purposes) - AI!
-              pattern: ^(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*\.[A-Za-z]{2,}$
-              message: Please enter the account ID for your AWS account. You can find your account ID in the AWS Management Console.
+              pattern: ^\d{12}$
+              message: Please enter your 12-digit AWS account ID. You can find your account ID in the AWS Management Console.
         - name: aws_region
           title: AWS Region
           help_text: >

--- a/replicated/providerconfigs-chart.yaml
+++ b/replicated/providerconfigs-chart.yaml
@@ -1,12 +1,13 @@
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
-  name: cloud-providers
+  name: providerconfigs
 spec:
   # chart identifies a matching chart from a .tgz
   chart:
     name: providerconfigs
-    chartVersion: 0.2.1
+    chartVersion: 0.2.2
+  namespace: serverless-pdf-chat
   weight: -20
 
   helmUpgradeFlags:

--- a/replicated/providers-chart.yaml
+++ b/replicated/providers-chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: kots.io/v1beta2
 kind: HelmChart
 metadata:
-  name: cloud-providers
+  name: providers
 spec:
   # chart identifies a matching chart from a .tgz
   chart:

--- a/replicated/serverless-pdf-chat-chart.yaml
+++ b/replicated/serverless-pdf-chat-chart.yaml
@@ -16,6 +16,10 @@ spec:
   # values are used in the customer environment, as a pre-render step
   # these values will be supplied to helm template
   values: 
+    aws:
+      accountId: '{{repl ConfigOption "aws_account_id" }}'
+      region: '{{repl ConfigOption "aws_region" }}'
+
     global:
       images:
         pullSecrets:

--- a/replicated/serverless-pdf-chat-chart.yaml
+++ b/replicated/serverless-pdf-chat-chart.yaml
@@ -6,7 +6,7 @@ spec:
   # chart identifies a matching chart from a .tgz
   chart:
     name: serverless-pdf-chat
-    chartVersion: 0.13.31
+    chartVersion: 0.13.32
   namespace: serverless-pdf-chat
   weight: 0 
 
@@ -19,7 +19,7 @@ spec:
     global:
       images:
         pullSecrets:
-          - {{repl ImagePullSecretName}}
+          - '{{repl ImagePullSecretName}}'
 
   optionalValues:
     - when: '{{repl HasLocalRegistry}}'

--- a/replicated/serverless-pdf-chat-chart.yaml
+++ b/replicated/serverless-pdf-chat-chart.yaml
@@ -6,7 +6,7 @@ spec:
   # chart identifies a matching chart from a .tgz
   chart:
     name: serverless-pdf-chat
-    chartVersion: 0.13.30
+    chartVersion: 0.13.31
   namespace: serverless-pdf-chat
   weight: 0 
 

--- a/replicated/serverless-pdf-chat-chart.yaml
+++ b/replicated/serverless-pdf-chat-chart.yaml
@@ -1,0 +1,32 @@
+apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: serverless-pdf-chat
+spec:
+  # chart identifies a matching chart from a .tgz
+  chart:
+    name: serverless-pdf-chat
+    chartVersion: 0.13.29
+  namespace: serverless-pdf-chat
+  weight: 0 
+
+  helmUpgradeFlags:
+    - --wait
+ 
+  # values are used in the customer environment, as a pre-render step
+  # these values will be supplied to helm template
+  values: {}
+  optionalValues:
+    - when: '{{repl HasLocalRegistry}}'
+      recursiveMerge: true
+      values: 
+        global:
+          images: 
+            registry: '{{repl LocalRegistryHost}}'
+
+    - when: '{{repl not HasLocalRegistry}}'
+      recursiveMerge: true
+      values: 
+        global:
+          images: 
+            registry: 'images.shortrib.io/proxy/{{repl LicenseFieldValue "appSlug"}}/429114214526.dkr.ecr.us-west-2.amazonaws.com'

--- a/replicated/serverless-pdf-chat-chart.yaml
+++ b/replicated/serverless-pdf-chat-chart.yaml
@@ -6,7 +6,7 @@ spec:
   # chart identifies a matching chart from a .tgz
   chart:
     name: serverless-pdf-chat
-    chartVersion: 0.13.29
+    chartVersion: 0.13.30
   namespace: serverless-pdf-chat
   weight: 0 
 

--- a/replicated/serverless-pdf-chat-chart.yaml
+++ b/replicated/serverless-pdf-chat-chart.yaml
@@ -19,7 +19,7 @@ spec:
     global:
       images:
         pullSecrets:
-          - name: {{repl ImagePullSecretName}}
+          - {{repl ImagePullSecretName}}
 
   optionalValues:
     - when: '{{repl HasLocalRegistry}}'

--- a/replicated/serverless-pdf-chat-chart.yaml
+++ b/replicated/serverless-pdf-chat-chart.yaml
@@ -15,7 +15,12 @@ spec:
  
   # values are used in the customer environment, as a pre-render step
   # these values will be supplied to helm template
-  values: {}
+  values: 
+    global:
+      images:
+        pullSecrets:
+          - name: {{repl ImagePullSecretName}}
+
   optionalValues:
     - when: '{{repl HasLocalRegistry}}'
       recursiveMerge: true


### PR DESCRIPTION
TL;DR
-----

Includes the front end chart in the Replicated release

Details
-------

Updates the Replicated release with the `serverless-pdf-chat` chart with includes the front-end application. There's more debugging to do and some enhancements I'd like to add, but I wanted to get this PR in because other charts needed  some work for pulling images from Replicated.
