### PR TITLE
Pulls providers through proxy

### DIFF
--- a/charts/providers/Chart.yaml
+++ b/charts/providers/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: providers
 description: A Helm chart for AWS Crossplane providers used in the Serverless PDF Chat application
 type: application
-version: 0.12.4
+version: 0.12.5
 appVersion: "1.0.20"

--- a/charts/providers/Chart.yaml
+++ b/charts/providers/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: providers
 description: A Helm chart for AWS Crossplane providers used in the Serverless PDF Chat application
 type: application
-version: 0.12.2
+version: 0.12.3
 appVersion: "1.0.20"

--- a/charts/providers/Chart.yaml
+++ b/charts/providers/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: providers
 description: A Helm chart for AWS Crossplane providers used in the Serverless PDF Chat application
 type: application
-version: 0.11.8
+version: 0.12.0
 appVersion: "1.0.20"

--- a/charts/providers/Chart.yaml
+++ b/charts/providers/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: providers
 description: A Helm chart for AWS Crossplane providers used in the Serverless PDF Chat application
 type: application
-version: 0.12.0
+version: 0.12.1
 appVersion: "1.0.20"

--- a/charts/providers/Chart.yaml
+++ b/charts/providers/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: providers
 description: A Helm chart for AWS Crossplane providers used in the Serverless PDF Chat application
 type: application
-version: 0.12.3
+version: 0.12.4
 appVersion: "1.0.20"

--- a/charts/providers/Chart.yaml
+++ b/charts/providers/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: providers
 description: A Helm chart for AWS Crossplane providers used in the Serverless PDF Chat application
 type: application
-version: 0.12.1
+version: 0.12.2
 appVersion: "1.0.20"

--- a/charts/providers/README.md
+++ b/charts/providers/README.md
@@ -35,10 +35,12 @@ The following table lists the configurable parameters of the chart and their def
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `global.images.registry` | Global registry for all images (overrides individual registry settings) | `""` |
+| `global.imagePullSecrets` | Global image pull secrets to use for all deployments | `[]` |
 | `commonLabels` | Common labels to add to all resources | `{}` |
 | `commonAnnotations` | Common annotations to add to all resources | `{}` |
 | `serviceAccount.create` | Whether to create a ServiceAccount | `true` |
 | `serviceAccount.name` | Name of the ServiceAccount to use (if not created) | `""` |
+| `aws.imagePullSecrets` | Image pull secrets for AWS providers | `[]` |
 | `aws.deploymentRuntimeConfig.resources.limits.cpu` | CPU limit for provider controllers | `500m` |
 | `aws.deploymentRuntimeConfig.resources.limits.memory` | Memory limit for provider controllers | `512Mi` |
 | `aws.deploymentRuntimeConfig.resources.requests.cpu` | CPU request for provider controllers | `100m` |
@@ -46,8 +48,10 @@ The following table lists the configurable parameters of the chart and their def
 | `aws.providers.registry` | Registry for all providers (overridden by global registry if set) | `xpkg.upbound.io/upbound` |
 | `aws.providers.<provider>.package` | Package name for the provider | Varies by provider |
 | `aws.providers.<provider>.version` | Version of the provider | `v1.21.1` |
+| `kubernetes.imagePullSecrets` | Image pull secrets for Kubernetes provider | `[]` |
 | `kubernetes.provider.version` | Version of the Kubernetes provider | `v0.17.2` |
 | `kubernetes.provider.registry` | Registry for the Kubernetes provider (overridden by global registry if set) | `xpkg.upbound.io/upbound` |
+| `jobs.imagePullSecrets` | Image pull secrets for jobs | `[]` |
 | `jobs.waitReadyJob.image.registry` | Registry for wait-ready job image (overridden by global registry if set) | `docker.io` |
 | `jobs.waitReadyJob.image.repository` | Repository for wait-ready job image | `bitnami/kubectl` |
 | `jobs.waitReadyJob.image.tag` | Tag for wait-ready job image | `latest` |
@@ -60,7 +64,7 @@ The following table lists the configurable parameters of the chart and their def
 | `jobs.waitReadyJob.securityContext.runAsUser` | User ID to run wait-ready job | `1001` |
 | `jobs.waitReadyJob.securityContext.runAsGroup` | Group ID to run wait-ready job | `1001` |
 
-### Registry Configuration Examples
+### Registry and Pull Secrets Configuration Examples
 
 To use a custom registry for all images:
 
@@ -79,6 +83,31 @@ global:
 aws:
   providers:
     registry: specific.registry.example.com
+```
+
+To configure image pull secrets for all providers:
+
+```yaml
+global:
+  imagePullSecrets:
+  - name: global-registry-secret
+```
+
+To configure image pull secrets for specific provider types:
+
+```yaml
+global:
+  imagePullSecrets:
+  - name: global-registry-secret
+aws:
+  imagePullSecrets:
+  - name: aws-registry-secret
+kubernetes:
+  imagePullSecrets:
+  - name: k8s-registry-secret
+jobs:
+  imagePullSecrets:
+  - name: jobs-registry-secret
 ```
 
 ## License

--- a/charts/providers/README.md
+++ b/charts/providers/README.md
@@ -35,7 +35,7 @@ The following table lists the configurable parameters of the chart and their def
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `global.images.registry` | Global registry for all images (overrides individual registry settings) | `""` |
-| `global.imagePullSecrets` | Global image pull secrets to use for all deployments | `[]` |
+| `global.images.pullSecrets` | Global list of image pull secret names for all images | `[]` |
 | `commonLabels` | Common labels to add to all resources | `{}` |
 | `commonAnnotations` | Common annotations to add to all resources | `{}` |
 | `serviceAccount.create` | Whether to create a ServiceAccount | `true` |
@@ -89,19 +89,22 @@ To configure image pull secrets for all providers:
 
 ```yaml
 global:
-  imagePullSecrets:
-  - name: global-registry-secret
+  images:
+    pullSecrets:
+    - global-registry-secret
 ```
 
 To configure image pull secrets for specific provider types:
 
 ```yaml
 global:
-  imagePullSecrets:
-  - name: global-registry-secret
+  images:
+    pullSecrets:
+    - global-registry-secret
 aws:
-  imagePullSecrets:
-  - name: aws-registry-secret
+  providers:
+    pullSecrets:
+    - aws-registry-secret
 kubernetes:
   imagePullSecrets:
   - name: k8s-registry-secret

--- a/charts/providers/templates/NOTES.txt
+++ b/charts/providers/templates/NOTES.txt
@@ -5,7 +5,7 @@ Crossplane providers have been successfully installed in your cluster.
 INSTALLED PROVIDERS:
 -------------------
 {{- range $key, $value := .Values.aws.providers }}
-{{- if and (ne $key "registry") ($value.version) }}
+{{- if and (ne $key "registry") (ne $key "pullSecrets") (hasKey $value "version") }}
 - AWS {{ $key }} (version: {{ $value.version }})
 {{- end }}
 {{- end }}

--- a/charts/providers/templates/_helpers.tpl
+++ b/charts/providers/templates/_helpers.tpl
@@ -84,7 +84,7 @@ Get the provider package URL
 {{- else -}}
   {{- $registry = .Values.aws.providers.registry -}}
 {{- end -}}
-{{- printf "%s/%s:%s" $registry $provider.package $provider.version -}}
+{{- printf "%s/upbound/%s:%s" $registry $provider.package $provider.version -}}
 {{- end }}
 
 {{/*

--- a/charts/providers/templates/_helpers.tpl
+++ b/charts/providers/templates/_helpers.tpl
@@ -113,7 +113,7 @@ global.images.pullSecrets takes precedence, then provider-specific pull secrets
 */}}
 {{- define "providers.packagePullSecrets" -}}
 {{- $pullSecrets := list -}}
-{{- if .root.Values.global.images.pullSecrets -}}
+{{- if and .root.Values.global.images .root.Values.global.images.pullSecrets -}}
   {{- $pullSecrets = .root.Values.global.images.pullSecrets -}}
 {{- else if and (eq .scope "aws") .root.Values.aws.imagePullSecrets -}}
   {{- $pullSecrets = .root.Values.aws.imagePullSecrets -}}
@@ -132,7 +132,7 @@ packagePullSecrets:
 Get image pull secrets for Kubernetes resources with proper precedence
 */}}
 {{- define "providers.imagePullSecrets" -}}
-{{- if .Values.global.images.pullSecrets }}
+{{- if and .Values.global.images .Values.global.images.pullSecrets }}
 imagePullSecrets:
 {{- range .Values.global.images.pullSecrets }}
 - name: {{ . }}

--- a/charts/providers/templates/_helpers.tpl
+++ b/charts/providers/templates/_helpers.tpl
@@ -115,8 +115,8 @@ global.images.pullSecrets takes precedence, then provider-specific pull secrets
 {{- $pullSecrets := list -}}
 {{- if and .root.Values.global.images .root.Values.global.images.pullSecrets -}}
   {{- $pullSecrets = .root.Values.global.images.pullSecrets -}}
-{{- else if and (eq .scope "aws") .root.Values.aws.imagePullSecrets -}}
-  {{- $pullSecrets = .root.Values.aws.imagePullSecrets -}}
+{{- else if and (eq .scope "aws") .root.Values.aws.providers.pullSecrets -}}
+  {{- $pullSecrets = .root.Values.aws.providers.pullSecrets -}}
 {{- else if and (eq .scope "kubernetes") .root.Values.kubernetes.imagePullSecrets -}}
   {{- $pullSecrets = .root.Values.kubernetes.imagePullSecrets -}}
 {{- end -}}

--- a/charts/providers/templates/_helpers.tpl
+++ b/charts/providers/templates/_helpers.tpl
@@ -77,14 +77,24 @@ Get the runtime config name
 Get the provider package URL
 */}}
 {{- define "providers.packageUrl" -}}
-{{- $provider := index .Values.aws.providers .providerName -}}
-{{- $registry := "" -}}
-{{- if and .Values.global .Values.global.images -}}
-  {{- $registry = .Values.global.images.registry | default .Values.aws.providers.registry -}}
+{{- if eq .scope "kubernetes" -}}
+  {{- $registry := "" -}}
+  {{- if and .Values.global .Values.global.images -}}
+    {{- $registry = .Values.global.images.registry | default .Values.kubernetes.provider.registry -}}
+  {{- else -}}
+    {{- $registry = .Values.kubernetes.provider.registry -}}
+  {{- end -}}
+  {{- printf "%s/upbound/provider-kubernetes:%s" $registry .Values.kubernetes.provider.version -}}
 {{- else -}}
-  {{- $registry = .Values.aws.providers.registry -}}
+  {{- $provider := index .Values.aws.providers .providerName -}}
+  {{- $registry := "" -}}
+  {{- if and .Values.global .Values.global.images -}}
+    {{- $registry = .Values.global.images.registry | default .Values.aws.providers.registry -}}
+  {{- else -}}
+    {{- $registry = .Values.aws.providers.registry -}}
+  {{- end -}}
+  {{- printf "%s/upbound/%s:%s" $registry $provider.package $provider.version -}}
 {{- end -}}
-{{- printf "%s/upbound/%s:%s" $registry $provider.package $provider.version -}}
 {{- end }}
 
 {{/*

--- a/charts/providers/templates/_helpers.tpl
+++ b/charts/providers/templates/_helpers.tpl
@@ -106,3 +106,30 @@ Get the registry for Kubernetes provider
 {{- define "providers.kubernetesRegistry" -}}
 {{- .Values.global.images.registry | default .Values.kubernetes.provider.registry -}}
 {{- end }}
+
+{{/*
+Get image pull secrets with proper precedence
+For AWS providers: global -> aws -> provider-specific
+For Kubernetes provider: global -> kubernetes
+For jobs: global -> jobs
+*/}}
+{{- define "providers.imagePullSecrets" -}}
+{{- $pullSecrets := list -}}
+{{- if .scope -}}
+  {{- if eq .scope "aws" -}}
+    {{- $pullSecrets = concat .root.Values.global.imagePullSecrets .root.Values.aws.imagePullSecrets -}}
+  {{- else if eq .scope "kubernetes" -}}
+    {{- $pullSecrets = concat .root.Values.global.imagePullSecrets .root.Values.kubernetes.imagePullSecrets -}}
+  {{- else if eq .scope "jobs" -}}
+    {{- $pullSecrets = concat .root.Values.global.imagePullSecrets .root.Values.jobs.imagePullSecrets -}}
+  {{- end -}}
+{{- else -}}
+  {{- $pullSecrets = .root.Values.global.imagePullSecrets -}}
+{{- end -}}
+{{- if $pullSecrets -}}
+imagePullSecrets:
+{{- range $pullSecrets }}
+- name: {{ .name }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/providers/templates/_helpers.tpl
+++ b/charts/providers/templates/_helpers.tpl
@@ -78,7 +78,12 @@ Get the provider package URL
 */}}
 {{- define "providers.packageUrl" -}}
 {{- $provider := index .Values.aws.providers .providerName -}}
-{{- $registry := .Values.global.images.registry | default .Values.aws.providers.registry -}}
+{{- $registry := "" -}}
+{{- if and .Values.global .Values.global.images -}}
+  {{- $registry = .Values.global.images.registry | default .Values.aws.providers.registry -}}
+{{- else -}}
+  {{- $registry = .Values.aws.providers.registry -}}
+{{- end -}}
 {{- printf "%s/%s:%s" $registry $provider.package $provider.version -}}
 {{- end }}
 
@@ -97,14 +102,22 @@ Get the ServiceAccount name for jobs
 Get the registry for jobs
 */}}
 {{- define "providers.jobRegistry" -}}
-{{- .Values.global.images.registry | default .Values.jobs.waitReadyJob.image.registry -}}
+{{- if and .Values.global .Values.global.images -}}
+  {{- .Values.global.images.registry | default .Values.jobs.waitReadyJob.image.registry -}}
+{{- else -}}
+  {{- .Values.jobs.waitReadyJob.image.registry -}}
+{{- end -}}
 {{- end }}
 
 {{/*
 Get the registry for Kubernetes provider
 */}}
 {{- define "providers.kubernetesRegistry" -}}
-{{- .Values.global.images.registry | default .Values.kubernetes.provider.registry -}}
+{{- if and .Values.global .Values.global.images -}}
+  {{- .Values.global.images.registry | default .Values.kubernetes.provider.registry -}}
+{{- else -}}
+  {{- .Values.kubernetes.provider.registry -}}
+{{- end -}}
 {{- end }}
 
 {{/*
@@ -113,7 +126,7 @@ global.images.pullSecrets takes precedence, then provider-specific pull secrets
 */}}
 {{- define "providers.packagePullSecrets" -}}
 {{- $pullSecrets := list -}}
-{{- if and .root.Values.global.images .root.Values.global.images.pullSecrets -}}
+{{- if and .root.Values.global .root.Values.global.images .root.Values.global.images.pullSecrets -}}
   {{- $pullSecrets = .root.Values.global.images.pullSecrets -}}
 {{- else if and (eq .scope "aws") .root.Values.aws.providers.pullSecrets -}}
   {{- $pullSecrets = .root.Values.aws.providers.pullSecrets -}}
@@ -132,7 +145,7 @@ packagePullSecrets:
 Get image pull secrets for Kubernetes resources with proper precedence
 */}}
 {{- define "providers.imagePullSecrets" -}}
-{{- if and .Values.global.images .Values.global.images.pullSecrets }}
+{{- if and .Values.global .Values.global.images .Values.global.images.pullSecrets }}
 imagePullSecrets:
 {{- range .Values.global.images.pullSecrets }}
 - name: {{ . }}

--- a/charts/providers/templates/_helpers.tpl
+++ b/charts/providers/templates/_helpers.tpl
@@ -117,19 +117,31 @@ For jobs: global -> jobs
 {{- $pullSecrets := list -}}
 {{- if .scope -}}
   {{- if eq .scope "aws" -}}
-    {{- $pullSecrets = concat .root.Values.global.imagePullSecrets .root.Values.aws.imagePullSecrets -}}
+    {{- if .root.Values.global.images.pullSecrets -}}
+      {{- $pullSecrets = .root.Values.global.images.pullSecrets -}}
+    {{- else if .root.Values.aws.imagePullSecrets -}}
+      {{- $pullSecrets = .root.Values.aws.imagePullSecrets -}}
+    {{- end -}}
   {{- else if eq .scope "kubernetes" -}}
-    {{- $pullSecrets = concat .root.Values.global.imagePullSecrets .root.Values.kubernetes.imagePullSecrets -}}
+    {{- if .root.Values.global.images.pullSecrets -}}
+      {{- $pullSecrets = .root.Values.global.images.pullSecrets -}}
+    {{- else if .root.Values.kubernetes.imagePullSecrets -}}
+      {{- $pullSecrets = .root.Values.kubernetes.imagePullSecrets -}}
+    {{- end -}}
   {{- else if eq .scope "jobs" -}}
-    {{- $pullSecrets = concat .root.Values.global.imagePullSecrets .root.Values.jobs.imagePullSecrets -}}
+    {{- if .root.Values.global.images.pullSecrets -}}
+      {{- $pullSecrets = .root.Values.global.images.pullSecrets -}}
+    {{- else if .root.Values.jobs.imagePullSecrets -}}
+      {{- $pullSecrets = .root.Values.jobs.imagePullSecrets -}}
+    {{- end -}}
   {{- end -}}
 {{- else -}}
-  {{- $pullSecrets = .root.Values.global.imagePullSecrets -}}
+  {{- $pullSecrets = .root.Values.global.images.pullSecrets -}}
 {{- end -}}
 {{- if $pullSecrets -}}
 imagePullSecrets:
 {{- range $pullSecrets }}
-- name: {{ .name }}
+- name: {{ . }}
 {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/providers/templates/_helpers.tpl
+++ b/charts/providers/templates/_helpers.tpl
@@ -108,40 +108,39 @@ Get the registry for Kubernetes provider
 {{- end }}
 
 {{/*
-Get image pull secrets with proper precedence
-For AWS providers: global -> aws -> provider-specific
-For Kubernetes provider: global -> kubernetes
-For jobs: global -> jobs
+Get package pull secrets for Crossplane providers with proper precedence
+global.images.pullSecrets takes precedence, then provider-specific pull secrets
 */}}
-{{- define "providers.imagePullSecrets" -}}
+{{- define "providers.packagePullSecrets" -}}
 {{- $pullSecrets := list -}}
-{{- if .scope -}}
-  {{- if eq .scope "aws" -}}
-    {{- if .root.Values.global.images.pullSecrets -}}
-      {{- $pullSecrets = .root.Values.global.images.pullSecrets -}}
-    {{- else if .root.Values.aws.imagePullSecrets -}}
-      {{- $pullSecrets = .root.Values.aws.imagePullSecrets -}}
-    {{- end -}}
-  {{- else if eq .scope "kubernetes" -}}
-    {{- if .root.Values.global.images.pullSecrets -}}
-      {{- $pullSecrets = .root.Values.global.images.pullSecrets -}}
-    {{- else if .root.Values.kubernetes.imagePullSecrets -}}
-      {{- $pullSecrets = .root.Values.kubernetes.imagePullSecrets -}}
-    {{- end -}}
-  {{- else if eq .scope "jobs" -}}
-    {{- if .root.Values.global.images.pullSecrets -}}
-      {{- $pullSecrets = .root.Values.global.images.pullSecrets -}}
-    {{- else if .root.Values.jobs.imagePullSecrets -}}
-      {{- $pullSecrets = .root.Values.jobs.imagePullSecrets -}}
-    {{- end -}}
-  {{- end -}}
-{{- else -}}
+{{- if .root.Values.global.images.pullSecrets -}}
   {{- $pullSecrets = .root.Values.global.images.pullSecrets -}}
+{{- else if and (eq .scope "aws") .root.Values.aws.imagePullSecrets -}}
+  {{- $pullSecrets = .root.Values.aws.imagePullSecrets -}}
+{{- else if and (eq .scope "kubernetes") .root.Values.kubernetes.imagePullSecrets -}}
+  {{- $pullSecrets = .root.Values.kubernetes.imagePullSecrets -}}
 {{- end -}}
 {{- if $pullSecrets -}}
-imagePullSecrets:
+packagePullSecrets:
 {{- range $pullSecrets }}
 - name: {{ . }}
 {{- end }}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Get image pull secrets for Kubernetes resources with proper precedence
+*/}}
+{{- define "providers.imagePullSecrets" -}}
+{{- if .Values.global.images.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.images.pullSecrets }}
+- name: {{ . }}
+{{- end }}
+{{- else if .Values.jobs.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.jobs.imagePullSecrets }}
+- name: {{ . }}
+{{- end }}
+{{- end }}
 {{- end -}}

--- a/charts/providers/templates/deployment-runtime-config.yaml
+++ b/charts/providers/templates/deployment-runtime-config.yaml
@@ -22,6 +22,7 @@ spec:
             runAsNonRoot: {{ .Values.aws.deploymentRuntimeConfig.securityContext.runAsNonRoot }}
             runAsUser: {{ .Values.aws.deploymentRuntimeConfig.securityContext.runAsUser }}
             runAsGroup: {{ .Values.aws.deploymentRuntimeConfig.securityContext.runAsGroup }}
+          {{- include "providers.imagePullSecrets" . | nindent 10 }}
           containers:
             - name: package-runtime
               resources:

--- a/charts/providers/templates/deployment-runtime-config.yaml
+++ b/charts/providers/templates/deployment-runtime-config.yaml
@@ -22,7 +22,7 @@ spec:
             runAsNonRoot: {{ .Values.aws.deploymentRuntimeConfig.securityContext.runAsNonRoot }}
             runAsUser: {{ .Values.aws.deploymentRuntimeConfig.securityContext.runAsUser }}
             runAsGroup: {{ .Values.aws.deploymentRuntimeConfig.securityContext.runAsGroup }}
-          {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 10 }}
+          {{- include "providers.packagePullSecrets" (dict "root" . "scope" "aws") | nindent 10 }}
           containers:
             - name: package-runtime
               resources:

--- a/charts/providers/templates/deployment-runtime-config.yaml
+++ b/charts/providers/templates/deployment-runtime-config.yaml
@@ -22,6 +22,7 @@ spec:
             runAsNonRoot: {{ .Values.aws.deploymentRuntimeConfig.securityContext.runAsNonRoot }}
             runAsUser: {{ .Values.aws.deploymentRuntimeConfig.securityContext.runAsUser }}
             runAsGroup: {{ .Values.aws.deploymentRuntimeConfig.securityContext.runAsGroup }}
+          {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 10 }}
           containers:
             - name: package-runtime
               resources:

--- a/charts/providers/templates/deployment-runtime-config.yaml
+++ b/charts/providers/templates/deployment-runtime-config.yaml
@@ -22,7 +22,6 @@ spec:
             runAsNonRoot: {{ .Values.aws.deploymentRuntimeConfig.securityContext.runAsNonRoot }}
             runAsUser: {{ .Values.aws.deploymentRuntimeConfig.securityContext.runAsUser }}
             runAsGroup: {{ .Values.aws.deploymentRuntimeConfig.securityContext.runAsGroup }}
-          {{- include "providers.packagePullSecrets" (dict "root" . "scope" "aws") | nindent 10 }}
           containers:
             - name: package-runtime
               resources:

--- a/charts/providers/templates/providers/provider-aws-apigateway.yaml
+++ b/charts/providers/templates/providers/provider-aws-apigateway.yaml
@@ -11,3 +11,4 @@ spec:
   skipDependencyResolution: true
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
+  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}

--- a/charts/providers/templates/providers/provider-aws-apigateway.yaml
+++ b/charts/providers/templates/providers/provider-aws-apigateway.yaml
@@ -11,4 +11,4 @@ spec:
   skipDependencyResolution: true
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
-  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}
+  {{- include "providers.packagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}

--- a/charts/providers/templates/providers/provider-aws-cognitoidp.yaml
+++ b/charts/providers/templates/providers/provider-aws-cognitoidp.yaml
@@ -11,3 +11,4 @@ spec:
   skipDependencyResolution: true
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
+  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}

--- a/charts/providers/templates/providers/provider-aws-cognitoidp.yaml
+++ b/charts/providers/templates/providers/provider-aws-cognitoidp.yaml
@@ -11,4 +11,4 @@ spec:
   skipDependencyResolution: true
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
-  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}
+  {{- include "providers.packagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}

--- a/charts/providers/templates/providers/provider-aws-dynamodb.yaml
+++ b/charts/providers/templates/providers/provider-aws-dynamodb.yaml
@@ -11,3 +11,4 @@ spec:
   skipDependencyResolution: true
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
+  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}

--- a/charts/providers/templates/providers/provider-aws-dynamodb.yaml
+++ b/charts/providers/templates/providers/provider-aws-dynamodb.yaml
@@ -11,4 +11,4 @@ spec:
   skipDependencyResolution: true
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
-  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}
+  {{- include "providers.packagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}

--- a/charts/providers/templates/providers/provider-aws-family.yaml
+++ b/charts/providers/templates/providers/provider-aws-family.yaml
@@ -11,3 +11,4 @@ spec:
   skipDependencyResolution: true
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
+  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}

--- a/charts/providers/templates/providers/provider-aws-family.yaml
+++ b/charts/providers/templates/providers/provider-aws-family.yaml
@@ -11,4 +11,4 @@ spec:
   skipDependencyResolution: true
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
-  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}
+  {{- include "providers.packagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}

--- a/charts/providers/templates/providers/provider-aws-iam.yaml
+++ b/charts/providers/templates/providers/provider-aws-iam.yaml
@@ -11,3 +11,4 @@ spec:
   skipDependencyResolution: true
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
+  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}

--- a/charts/providers/templates/providers/provider-aws-iam.yaml
+++ b/charts/providers/templates/providers/provider-aws-iam.yaml
@@ -11,4 +11,4 @@ spec:
   skipDependencyResolution: true
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
-  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}
+  {{- include "providers.packagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}

--- a/charts/providers/templates/providers/provider-aws-lambda.yaml
+++ b/charts/providers/templates/providers/provider-aws-lambda.yaml
@@ -11,3 +11,4 @@ spec:
   skipDependencyResolution: true
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
+  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}

--- a/charts/providers/templates/providers/provider-aws-lambda.yaml
+++ b/charts/providers/templates/providers/provider-aws-lambda.yaml
@@ -11,4 +11,4 @@ spec:
   skipDependencyResolution: true
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
-  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}
+  {{- include "providers.packagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}

--- a/charts/providers/templates/providers/provider-aws-s3.yaml
+++ b/charts/providers/templates/providers/provider-aws-s3.yaml
@@ -11,3 +11,4 @@ spec:
   skipDependencyResolution: true
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
+  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}

--- a/charts/providers/templates/providers/provider-aws-s3.yaml
+++ b/charts/providers/templates/providers/provider-aws-s3.yaml
@@ -11,4 +11,4 @@ spec:
   skipDependencyResolution: true
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
-  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}
+  {{- include "providers.packagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}

--- a/charts/providers/templates/providers/provider-aws-sqs.yaml
+++ b/charts/providers/templates/providers/provider-aws-sqs.yaml
@@ -11,3 +11,4 @@ spec:
   skipDependencyResolution: true
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
+  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}

--- a/charts/providers/templates/providers/provider-aws-sqs.yaml
+++ b/charts/providers/templates/providers/provider-aws-sqs.yaml
@@ -11,4 +11,4 @@ spec:
   skipDependencyResolution: true
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
-  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}
+  {{- include "providers.packagePullSecrets" (dict "root" . "scope" "aws") | nindent 2 }}

--- a/charts/providers/templates/providers/provider-kubernetes.yaml
+++ b/charts/providers/templates/providers/provider-kubernetes.yaml
@@ -13,4 +13,4 @@ spec:
   revisionHistoryLimit: 1
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
-  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "kubernetes") | nindent 2 }}
+  {{- include "providers.packagePullSecrets" (dict "root" . "scope" "kubernetes") | nindent 2 }}

--- a/charts/providers/templates/providers/provider-kubernetes.yaml
+++ b/charts/providers/templates/providers/provider-kubernetes.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     {{- include "providers.annotations" . | nindent 4 }}
 spec:
-  package: "{{ include "providers.kubernetesRegistry" . }}/provider-kubernetes:{{ .Values.kubernetes.provider.version }}"
+  package: {{ include "providers.packageUrl" (dict "Values" .Values "scope" "kubernetes") }}
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1

--- a/charts/providers/templates/providers/provider-kubernetes.yaml
+++ b/charts/providers/templates/providers/provider-kubernetes.yaml
@@ -13,3 +13,4 @@ spec:
   revisionHistoryLimit: 1
   runtimeConfigRef:
     name: {{ include "providers.runtimeConfigName" . }}
+  {{- include "providers.imagePullSecrets" (dict "root" . "scope" "kubernetes") | nindent 2 }}

--- a/charts/providers/templates/wait-ready-job.yaml
+++ b/charts/providers/templates/wait-ready-job.yaml
@@ -23,7 +23,7 @@ spec:
         runAsUser: {{ .runAsUser }}
         runAsGroup: {{ .runAsGroup }}
       {{- end }}
-      {{- include "providers.imagePullSecrets" (dict "root" . "scope" "jobs") | nindent 6 }}
+      {{- include "providers.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: kubectl
         image: {{ include "providers.jobRegistry" . }}/{{ .Values.jobs.waitReadyJob.image.repository }}:{{ .Values.jobs.waitReadyJob.image.tag | default "latest" }}

--- a/charts/providers/templates/wait-ready-job.yaml
+++ b/charts/providers/templates/wait-ready-job.yaml
@@ -23,6 +23,7 @@ spec:
         runAsUser: {{ .runAsUser }}
         runAsGroup: {{ .runAsGroup }}
       {{- end }}
+      {{- include "providers.imagePullSecrets" (dict "root" . "scope" "jobs") | nindent 6 }}
       containers:
       - name: kubectl
         image: {{ include "providers.jobRegistry" . }}/{{ .Values.jobs.waitReadyJob.image.repository }}:{{ .Values.jobs.waitReadyJob.image.tag | default "latest" }}

--- a/charts/providers/templates/wait-ready-job.yaml
+++ b/charts/providers/templates/wait-ready-job.yaml
@@ -40,7 +40,7 @@ spec:
           
           # Wait for all AWS providers to be ready
           {{- range $key, $value := .Values.aws.providers }}
-          {{- if and (ne $key "registry") (ne $key "bedrock") (ne $key "cloudfront") (ne $key "secretsmanager") }}
+          {{- if and (ne $key "registry") (ne $key "bedrock") (ne $key "cloudfront") (ne $key "secretsmanager") (ne $key "pullSecrets") }}
           echo "Waiting for provider {{ include "providers.fullname" $ }}-aws-{{ $key }} to be ready..."
           kubectl wait --for=condition=Healthy provider.pkg.crossplane.io/{{ include "providers.fullname" $ }}-aws-{{ $key }} --timeout=300s
           if [ $? -ne 0 ]; then

--- a/charts/providers/values.schema.json
+++ b/charts/providers/values.schema.json
@@ -11,18 +11,13 @@
             "registry": {
               "type": "string",
               "description": "Global registry configuration. When set, overrides individual registry settings unless specifically overridden at the component level"
-            }
-          }
-        },
-        "imagePullSecrets": {
-          "type": "array",
-          "description": "Global image pull secrets to use for all deployments",
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "Name of the image pull secret"
+            },
+            "pullSecrets": {
+              "type": "array",
+              "description": "Global list of image pull secret names",
+              "default": [],
+              "items": {
+                "type": "string"
               }
             }
           }

--- a/charts/providers/values.schema.json
+++ b/charts/providers/values.schema.json
@@ -13,6 +13,19 @@
               "description": "Global registry configuration. When set, overrides individual registry settings unless specifically overridden at the component level"
             }
           }
+        },
+        "imagePullSecrets": {
+          "type": "array",
+          "description": "Global image pull secrets to use for all deployments",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the image pull secret"
+              }
+            }
+          }
         }
       }
     },
@@ -55,6 +68,19 @@
     "jobs": {
       "type": "object",
       "properties": {
+        "imagePullSecrets": {
+          "type": "array",
+          "description": "Image pull secrets for jobs",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the image pull secret"
+              }
+            }
+          }
+        },
         "waitReadyJob": {
           "type": "object",
           "properties": {
@@ -146,6 +172,19 @@
     "aws": {
       "type": "object",
       "properties": {
+        "imagePullSecrets": {
+          "type": "array",
+          "description": "Image pull secrets for AWS providers",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the image pull secret"
+              }
+            }
+          }
+        },
         "deploymentRuntimeConfig": {
           "type": "object",
           "properties": {
@@ -341,6 +380,19 @@
     "kubernetes": {
       "type": "object",
       "properties": {
+        "imagePullSecrets": {
+          "type": "array",
+          "description": "Image pull secrets for Kubernetes provider",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the image pull secret"
+              }
+            }
+          }
+        },
         "provider": {
           "type": "object",
           "properties": {

--- a/charts/providers/values.schema.json
+++ b/charts/providers/values.schema.json
@@ -248,6 +248,14 @@
               "description": "Registry for all providers",
               "default": "xpkg.upbound.io/upbound"
             },
+            "pullSecrets": {
+              "type": "array",
+              "description": "List of image pull secret names for AWS providers",
+              "default": [],
+              "items": {
+                "type": "string"
+              }
+            },
             "family": {
               "type": "object",
               "properties": {

--- a/charts/providers/values.yaml
+++ b/charts/providers/values.yaml
@@ -6,6 +6,9 @@ global:
     # Global registry configuration. When set, overrides individual registry settings
     # unless specifically overridden at the component level
     registry: ""
+  # Global image pull secrets to use for all deployments
+  imagePullSecrets: []
+  # - name: regcred
 
 nameOverride: ""
 fullnameOverride: ""
@@ -33,6 +36,9 @@ serviceAccount:
 
 # Job configurations
 jobs:
+  # Image pull secrets for jobs
+  imagePullSecrets: []
+  # - name: regcred
   waitReadyJob:
     image:
       # Can be overridden by global.images.registry
@@ -53,6 +59,10 @@ jobs:
       runAsGroup: 1001
 
 aws:
+  # Image pull secrets for AWS providers
+  imagePullSecrets: []
+  # - name: regcred
+  
   # Deployment runtime configuration
   deploymentRuntimeConfig:
     # Resource limits for provider controllers
@@ -99,6 +109,10 @@ aws:
       version: "v1.21.1"
 
 kubernetes:
+  # Image pull secrets for Kubernetes provider
+  imagePullSecrets: []
+  # - name: regcred
+  
   provider:
     version: "v0.17.2"
     # Can be overridden by global.images.registry

--- a/charts/providers/values.yaml
+++ b/charts/providers/values.yaml
@@ -81,7 +81,7 @@ aws:
   providers:
     # Registry for all providers - can be overridden by global.images.registry
     # Can be overridden by global.images.registry
-    registry: "xpkg.upbound.io/upbound"
+    registry: "xpkg.upbound.io"
     # Pull secrets for AWS providers
     pullSecrets: []
     family:
@@ -117,4 +117,4 @@ kubernetes:
   provider:
     version: "v0.17.2"
     # Can be overridden by global.images.registry
-    registry: "xpkg.upbound.io/upbound"
+    registry: "xpkg.upbound.io"

--- a/charts/providers/values.yaml
+++ b/charts/providers/values.yaml
@@ -82,6 +82,8 @@ aws:
     # Registry for all providers - can be overridden by global.images.registry
     # Can be overridden by global.images.registry
     registry: "xpkg.upbound.io/upbound"
+    # Pull secrets for AWS providers
+    pullSecrets: []
     family:
       package: "provider-family-aws"
       version: "v1.21.1"

--- a/charts/providers/values.yaml
+++ b/charts/providers/values.yaml
@@ -6,9 +6,8 @@ global:
     # Global registry configuration. When set, overrides individual registry settings
     # unless specifically overridden at the component level
     registry: ""
-  # Global image pull secrets to use for all deployments
-  imagePullSecrets: []
-  # - name: regcred
+    # Global pull secrets for all images
+    pullSecrets: []
 
 nameOverride: ""
 fullnameOverride: ""

--- a/replicated/embeddedcluster.yaml
+++ b/replicated/embeddedcluster.yaml
@@ -4,6 +4,9 @@ metadata:
   name: serverless-pdf-chat
 spec:
   version: 2.3.1+k8s-1.30
+  domains:
+    proxyRegistryDomain: images.shortrib.io
+    replicatedAppDomain: updates.shortrib.io
   extensions:
     helm:
       repositories:

--- a/replicated/providers-chart.yaml
+++ b/replicated/providers-chart.yaml
@@ -6,7 +6,7 @@ spec:
   # chart identifies a matching chart from a .tgz
   chart:
     name: providers
-    chartVersion: 0.12.3
+    chartVersion: 0.12.4
   namespace: serverless-pdf-chat
   weight: -30
 
@@ -32,4 +32,4 @@ spec:
       values: 
         global:
           images: 
-            registry: 'images.shortrib.io/proxy/{{repl LicenseFieldValue "appSlug"}}/429114214526.dkr.ecr.us-west-2.amazonaws.com'
+            registry: 'images.shortrib.io/proxy/{{repl LicenseFieldValue "appSlug"}}/xpkg.upbound.io'

--- a/replicated/providers-chart.yaml
+++ b/replicated/providers-chart.yaml
@@ -12,3 +12,24 @@ spec:
 
   helmUpgradeFlags:
     - --wait
+
+  values: 
+    global:
+      images:
+        pullSecrets:
+          - '{{repl ImagePullSecretName}}'
+
+  optionalValues:
+    - when: '{{repl HasLocalRegistry}}'
+      recursiveMerge: true
+      values: 
+        global:
+          images: 
+            registry: '{{repl LocalRegistryHost}}'
+
+    - when: '{{repl not HasLocalRegistry}}'
+      recursiveMerge: true
+      values: 
+        global:
+          images: 
+            registry: 'images.shortrib.io/proxy/{{repl LicenseFieldValue "appSlug"}}/429114214526.dkr.ecr.us-west-2.amazonaws.com'

--- a/replicated/providers-chart.yaml
+++ b/replicated/providers-chart.yaml
@@ -6,7 +6,7 @@ spec:
   # chart identifies a matching chart from a .tgz
   chart:
     name: providers
-    chartVersion: 0.12.4
+    chartVersion: 0.12.5
   namespace: serverless-pdf-chat
   weight: -30
 

--- a/replicated/providers-chart.yaml
+++ b/replicated/providers-chart.yaml
@@ -30,11 +30,12 @@ spec:
     - when: '{{repl not HasLocalRegistry}}'
       recursiveMerge: true
       values: 
-        global:
-          images: 
-            registry: 'images.shortrib.io/proxy/{{repl LicenseFieldValue "appSlug"}}'
-        providers:
-          registry: 'images.shortrib.io/proxy/{{repl LicenseFieldValue "appSlug"}}/xpkg.upbound.io'
+        aws:
+          providers:
+            registry: 'images.shortrib.io/proxy/{{repl LicenseFieldValue "appSlug"}}/xpkg.upbound.io'
+        kubernetes:
+          provider:
+            registry: 'images.shortrib.io/proxy/{{repl LicenseFieldValue "appSlug"}}/xpkg.upbound.io'
         jobs:
           image:
             registry: 'images.shortrib.io/proxy/{{repl LicenseFieldValue "appSlug"}}/index.docker.io'

--- a/replicated/providers-chart.yaml
+++ b/replicated/providers-chart.yaml
@@ -6,7 +6,7 @@ spec:
   # chart identifies a matching chart from a .tgz
   chart:
     name: providers
-    chartVersion: 0.11.8
+    chartVersion: 0.12.0
   namespace: serverless-pdf-chat
   weight: -30
 

--- a/replicated/providers-chart.yaml
+++ b/replicated/providers-chart.yaml
@@ -6,7 +6,7 @@ spec:
   # chart identifies a matching chart from a .tgz
   chart:
     name: providers
-    chartVersion: 0.12.0
+    chartVersion: 0.12.1
   namespace: serverless-pdf-chat
   weight: -30
 

--- a/replicated/providers-chart.yaml
+++ b/replicated/providers-chart.yaml
@@ -6,7 +6,7 @@ spec:
   # chart identifies a matching chart from a .tgz
   chart:
     name: providers
-    chartVersion: 0.12.2
+    chartVersion: 0.12.3
   namespace: serverless-pdf-chat
   weight: -30
 

--- a/replicated/providers-chart.yaml
+++ b/replicated/providers-chart.yaml
@@ -32,4 +32,9 @@ spec:
       values: 
         global:
           images: 
-            registry: 'images.shortrib.io/proxy/{{repl LicenseFieldValue "appSlug"}}/xpkg.upbound.io'
+            registry: 'images.shortrib.io/proxy/{{repl LicenseFieldValue "appSlug"}}'
+        providers:
+          registry: 'images.shortrib.io/proxy/{{repl LicenseFieldValue "appSlug"}}/xpkg.upbound.io'
+        jobs:
+          image:
+            registry: 'images.shortrib.io/proxy/{{repl LicenseFieldValue "appSlug"}}/index.docker.io'

--- a/replicated/providers-chart.yaml
+++ b/replicated/providers-chart.yaml
@@ -6,7 +6,7 @@ spec:
   # chart identifies a matching chart from a .tgz
   chart:
     name: providers
-    chartVersion: 0.12.1
+    chartVersion: 0.12.2
   namespace: serverless-pdf-chat
   weight: -30
 


### PR DESCRIPTION
TL;DR
-----

Enhanced providers chart to support private registries and image pull
secrets with a focus on enabling proxy-based image pulls for
air-gapped environments.

Details
-------

This PR adds comprehensive support for private registry configurations
and image pull secrets in the providers Helm chart, allowing
deployments to work in air-gapped environments by pulling provider
images through proxy services.

The key changes include:

1. Added full support for image pull secrets at global, provider-type,
   and component-specific levels
2. Enhanced the way registry paths are constructed to ensure proper
   formatting with different registry patterns
3. Updated the helpers template with new functions to handle pull
   secret configuration with proper precedence rules
4. Ensured all provider templates use the new pull secrets
   configuration options
5. Updated documentation to explain the new configuration options for
   registries and pull secrets
6. Added Replicated configuration to support proxy-based image pulls
   when deploying in air-gapped environments
7. Configured the embedded cluster to use specific proxy domains for
   registry and application updates

This change allows customers with strict network security requirements
to deploy the application in environments without direct access to
public image registries, while maintaining the same functionality by
routing image pulls through a trusted proxy.
