### PR TITLE
Exposes frontend outside of the cluster

### DIFF
--- a/charts/serverless-pdf-chat/Chart.yaml
+++ b/charts/serverless-pdf-chat/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: serverless-pdf-chat
 description: A Helm chart for deploying serverless PDF chat infrastructure
 type: application
-version: 0.13.35  # Bumped from 0.13.34 to 0.13.35
+version: 0.14.1  # Bumped from 0.14.0 to 0.14.1 for NodePort TLS support
 appVersion: "1.0.20"  # Bumping from 1.0.16 to 1.0.17

--- a/charts/serverless-pdf-chat/templates/frontend/deployment.yaml
+++ b/charts/serverless-pdf-chat/templates/frontend/deployment.yaml
@@ -65,6 +65,14 @@ spec:
       volumes:
         - name: app-build
           emptyDir: {}
+        {{- if and .Values.tls (eq .Values.frontend.service.type "NodePort") }}
+        - name: tls-certs
+          secret:
+            secretName: {{ include "serverless-pdf-chat.fullname" . }}-tls
+        - name: nginx-conf
+          configMap:
+            name: {{ include "serverless-pdf-chat.fullname" . }}-nginx-conf
+        {{- end }}
       initContainers:
         - name: {{ .Chart.Name }}-builder
           image: {{ include "serverless-pdf-chat.frontendBuilderImage" . }}
@@ -123,6 +131,15 @@ spec:
           volumeMounts:
             - name: app-build
               mountPath: /usr/share/nginx/html
+            {{- if and .Values.tls (eq .Values.frontend.service.type "NodePort") }}
+            - name: tls-certs
+              mountPath: /etc/nginx/ssl
+              readOnly: true
+            - name: nginx-conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+            {{- end }}
       {{- with .Values.frontend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/serverless-pdf-chat/templates/frontend/ingress.yaml
+++ b/charts/serverless-pdf-chat/templates/frontend/ingress.yaml
@@ -18,12 +18,20 @@ spec:
   {{- end }}
   {{- if .Values.frontend.ingress.tls }}
   tls:
+    {{- if .Values.tls }}
+    - hosts:
+        {{- range (index .Values.frontend.ingress.tls 0).hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ include "serverless-pdf-chat.fullname" $ }}-tls
+    {{- else }}
     {{- range .Values.frontend.ingress.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
         {{- end }}
       secretName: {{ .secretName }}
+    {{- end }}
     {{- end }}
   {{- end }}
   rules:

--- a/charts/serverless-pdf-chat/templates/frontend/nginx-config.yaml
+++ b/charts/serverless-pdf-chat/templates/frontend/nginx-config.yaml
@@ -1,0 +1,58 @@
+{{- if and .Values.frontend.enabled (eq .Values.frontend.service.type "NodePort") .Values.tls }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "serverless-pdf-chat.fullname" . }}-nginx-conf
+  labels:
+    {{- include "serverless-pdf-chat.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+data:
+  nginx.conf: |
+    user  nginx;
+    worker_processes  auto;
+    
+    error_log  /var/log/nginx/error.log notice;
+    pid        /var/run/nginx.pid;
+    
+    events {
+        worker_connections  1024;
+    }
+    
+    http {
+        include       /etc/nginx/mime.types;
+        default_type  application/octet-stream;
+        
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+        
+        access_log  /var/log/nginx/access.log  main;
+        
+        sendfile        on;
+        keepalive_timeout  65;
+        
+        server {
+            listen 80;
+            listen 443 ssl;
+            
+            server_name  _;
+            
+            ssl_certificate     /etc/nginx/ssl/tls.crt;
+            ssl_certificate_key /etc/nginx/ssl/tls.key;
+            ssl_protocols       TLSv1.2 TLSv1.3;
+            ssl_ciphers         HIGH:!aNULL:!MD5;
+            
+            location / {
+                root   /usr/share/nginx/html;
+                index  index.html index.htm;
+                try_files $uri $uri/ /index.html;
+            }
+            
+            # redirect server error pages to the static page /50x.html
+            error_page   500 502 503 504  /50x.html;
+            location = /50x.html {
+                root   /usr/share/nginx/html;
+            }
+        }
+    }
+{{- end }}

--- a/charts/serverless-pdf-chat/templates/frontend/service.yaml
+++ b/charts/serverless-pdf-chat/templates/frontend/service.yaml
@@ -13,10 +13,23 @@ metadata:
 spec:
   type: {{ .Values.frontend.service.type }}
   ports:
+    {{- if and (eq .Values.frontend.service.type "NodePort") .Values.tls }}
+    - port: 443
+      targetPort: 443
+      protocol: TCP
+      name: https
+      {{- if .Values.frontend.service.nodePort }}
+      nodePort: {{ .Values.frontend.service.nodePort | int }}
+      {{- end }}
+    {{- else }}
     - port: {{ .Values.frontend.service.port }}
       targetPort: http
       protocol: TCP
       name: http
+      {{- if and (eq .Values.frontend.service.type "NodePort") .Values.frontend.service.nodePort }}
+      nodePort: {{ .Values.frontend.service.nodePort | int }}
+      {{- end }}
+    {{- end }}
   selector:
     {{- include "serverless-pdf-chat.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: frontend

--- a/charts/serverless-pdf-chat/templates/frontend/tls-secret.yaml
+++ b/charts/serverless-pdf-chat/templates/frontend/tls-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.tls -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "serverless-pdf-chat.fullname" . }}-tls
+  labels:
+    {{- include "serverless-pdf-chat.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.tls.cert | b64enc }}
+  tls.key: {{ .Values.tls.key | b64enc }}
+  {{- if .Values.tls.ca }}
+  ca.crt: {{ .Values.tls.ca | b64enc }}
+  {{- end }}
+{{- end -}}

--- a/charts/serverless-pdf-chat/values.schema.json
+++ b/charts/serverless-pdf-chat/values.schema.json
@@ -811,6 +811,10 @@
             "annotations": {
               "type": "object",
               "description": "Service annotations"
+            },
+            "nodePort": {
+              "type": ["integer", "string", "null"],
+              "description": "Node port when service type is NodePort"
             }
           }
         },
@@ -893,6 +897,25 @@
       "additionalProperties": {
         "type": "string"
       }
+    },
+    "tls": {
+      "type": "object",
+      "description": "TLS certificate configuration",
+      "properties": {
+        "cert": {
+          "type": "string",
+          "description": "TLS certificate in PEM format"
+        },
+        "key": {
+          "type": "string",
+          "description": "TLS private key in PEM format"
+        },
+        "ca": {
+          "type": "string",
+          "description": "CA certificate in PEM format (optional)"
+        }
+      },
+      "required": ["cert", "key"]
     }
   }
 }

--- a/charts/serverless-pdf-chat/values.yaml
+++ b/charts/serverless-pdf-chat/values.yaml
@@ -62,6 +62,7 @@ frontend:
     type: "ClusterIP"
     port: 80
     annotations: {}
+    # nodePort: 443 # Only used when type is NodePort
   ingress:
     enabled: true
     className: "nginx"
@@ -75,6 +76,12 @@ frontend:
       - secretName: "pdf-chat-tls"
         hosts:
           - "pdf-chat.example.com"
+
+# TLS certificate settings
+tls:
+  cert: "" # TLS certificate (PEM format)
+  key: ""  # TLS private key (PEM format)
+  ca: ""   # CA certificate (PEM format, optional)
 
 aws:
   region: "us-west-2"

--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -5,9 +5,96 @@ metadata:
   name: serverless-pdf-chat
 spec:
   groups:
+    - name: access
+      title: Application Access
+      description: |
+        You can customize how you will expose Serverless PDF Chat to the internet.
+
+        Common configurations include:
+
+        - **ClusterIP** Using a Cluster IP and configuring your existing ingress controller to route traffic to Serverless PDF Chat
+        - **NodePort** Using a NodePort and configuring an existing load balancer to route traffic to Serverless PDF Chat
+        - **LoadBalancer** Using a LoadBalancer service and letting Kubernetes provision a load balancer for you
+
+        If you're running in a supported cloud provider and want Kubernetes to provision a Load Balancer, use LoadBalancer.
+      items:
+        - name: domain
+          title: Ingress Hostname
+          help_text: >
+            The domain name at which you'll access Serverless PDF Chat. Don't include
+            the `https://` or any path elements.
+          type: text
+          required: true
+          validation:
+            regex:
+              pattern: "^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
+              message: Please enter a valid hostname
+
+        - name: service_type
+          title: Service Type
+          type: select_one
+          items:
+            - name: cluster_ip
+              title: ClusterIP
+            - name: node_port
+              title: NodePort
+            - name: load_balancer
+              title: LoadBalancer
+          default: cluster_ip
+        - name: node_port_port
+          title: Node Port
+          help_text: >
+              (Optional) - The port to use for the NodePort service type. Leave this blank to have Kubernetes choose a port for you.
+          type: text
+          default: "443"
+          when: repl{{ ConfigOptionEquals "service_type" "node_port" }}
+
+    - name: tls
+      title: Certificates
+      description: |
+        You can secure the Serverless PDF Chat application with certificates from a trusted certificate authority
+        or we can generate them for you. We recommend that you upload your own certificates for production installations.
+      items:
+        - name: certificate_source
+          type: select_one
+          title: Certificate Source
+          default: generate_internal
+          items:
+            - name: generate_internal
+              title: Generate
+            - name: upload_existing
+              title: Upload
+        - name: tls_cert
+          title: Certificate
+          type: file
+          when: '{{repl ConfigOptionEquals "certificate_source" "upload_existing"}}'
+        - name: tls_key
+          title: Private Key
+          type: file
+          when: '{{repl ConfigOptionEquals "certificate_source" "upload_existing"}}'
+        - name: tls_ca
+          title: Signing Authority
+          type: file
+          when: '{{repl ConfigOptionEquals "certificate_source" "upload_existing"}}'
+        - name: generated_tls
+          title: Generated TLS
+          type: textarea
+          hidden: true
+          default: |-
+            repl{{ $ca := genCA (ConfigOption "domain") 365 }}
+            repl{{ $tls := dict "ca" $ca }}
+            repl{{ $cert := genSignedCert (ConfigOption "domain") (list ) (list (ConfigOption "domain")) 365 $ca }}
+            repl{{ $_ := set $tls "cert" $cert }}
+            repl{{ toJson $tls }}
+          when: '{{repl ConfigOptionEquals "certificate_source" "generate_internal"}}'
+
     - name: aws
       title: AWS Configuration
       description: |
+        This section can be used to configure the AWS resources required by Serverless PDF Chat. The application
+        will create new resources in your AWS account.
+
+        Be sure the AWS credentials you provide have the necessary permissions to create resources in your AWS account.
       items:
         - name: aws_account_id
           title: AWS Account ID

--- a/replicated/serverless-pdf-chat-chart.yaml
+++ b/replicated/serverless-pdf-chat-chart.yaml
@@ -6,7 +6,7 @@ spec:
   # chart identifies a matching chart from a .tgz
   chart:
     name: serverless-pdf-chat
-    chartVersion: 0.13.35
+    chartVersion: 0.14.1
   namespace: serverless-pdf-chat
   weight: 0 
 
@@ -20,12 +20,24 @@ spec:
       accountId: '{{repl ConfigOption "aws_account_id" }}'
       region: '{{repl ConfigOption "aws_region" }}'
 
+    frontend:
+      ingress:
+        hosts:
+          - host: '{{repl ConfigOption "domain" }}'
+            paths:
+              - path: "/"
+                pathType: "Prefix"
+        tls:
+          - hosts:
+              - '{{repl ConfigOption "domain" }}'
+
     global:
       images:
         pullSecrets:
           - '{{repl ImagePullSecretName}}'
 
   optionalValues:
+    # Registry configuration
     - when: '{{repl HasLocalRegistry}}'
       recursiveMerge: true
       values: 
@@ -39,3 +51,49 @@ spec:
         global:
           images: 
             registry: 'images.shortrib.io/proxy/{{repl LicenseFieldValue "appSlug"}}/429114214526.dkr.ecr.us-west-2.amazonaws.com'
+
+    # TLS certificate configuration
+    - when: '{{repl ConfigOptionEquals "certificate_source" "upload_existing" }}'
+      recursiveMerge: true
+      values:
+        tls:
+          cert: | 
+            '{{repl ConfigOptionData "tls_cert" | nindent 12 }}'
+          key: | 
+            '{{repl ConfigOptionData "tls_key" | nindent 12 }}'
+          ca: | 
+            '{{repl ConfigOptionData "tls_ca" | nindent 12 }}'
+
+    - when: '{{repl ConfigOptionEquals "certificate_source" "generate_internal" }}'
+      recursiveMerge: true
+      values:
+        tls:
+          cert: | 
+            '{{repl fromJson (ConfigOption "generated_tls") | dig "cert" "Cert" "" | nindent 12 }}'
+          key: | 
+            '{{repl fromJson (ConfigOption "generated_tls") | dig "cert" "Key" "" | nindent 12 }}'
+          ca: | 
+            '{{repl fromJson (ConfigOption "generated_tls") | dig "ca" "Cert" "" | nindent 12 }}'
+            
+    # Service type configuration
+    - when: '{{repl ConfigOptionEquals "service_type" "cluster_ip" }}'
+      recursiveMerge: true
+      values:
+        frontend:
+          service:
+            type: ClusterIP
+
+    - when: '{{repl ConfigOptionEquals "service_type" "node_port" }}'
+      recursiveMerge: true
+      values:
+        frontend:
+          service:
+            type: NodePort
+            nodePort: '{{repl ConfigOption "node_port_port" }}'
+
+    - when: '{{repl ConfigOptionEquals "service_type" "load_balancer" }}'
+      recursiveMerge: true
+      values:
+        frontend:
+          service:
+            type: LoadBalancer


### PR DESCRIPTION
TL;DR
-----

Adds configuration options for hostname, access methods (ingress/nodeport/loadbalancer), and TLS certificates to allow deploying the application in various networking environments.

Details
-------

This change enhances deployment flexibility by adding admin console configuration options that enable the application to be exposed externally in different ways:

- Adds hostname configuration for defining the application's domain name
- Provides three service type options:
  - ClusterIP (default) for use with existing ingress controllers
  - NodePort for direct node access with optional port specification
  - LoadBalancer for cloud provider load balancer integration
- Implements TLS certificate management:
  - Option to generate self-signed certificates automatically
  - Option to upload existing certificates from a trusted CA
  - Properly configures TLS termination at pod level for NodePort services
  - Creates and mounts custom Nginx configuration for direct TLS termination

These changes allow administrators to customize how the application is exposed based on their specific infrastructure and security requirements, making the solution more adaptable to different Kubernetes environments.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
