### PR TITLE
fix: resolve AWS resource naming and providerconfigs schema issues

### DIFF
--- a/charts/providerconfigs/values.schema.json
+++ b/charts/providerconfigs/values.schema.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "additionalProperties": false,
   "required": ["aws", "kubernetes"],
   "properties": {
     "nameOverride": {

--- a/charts/serverless-pdf-chat/templates/_helpers.tpl
+++ b/charts/serverless-pdf-chat/templates/_helpers.tpl
@@ -14,9 +14,9 @@ Create a default fully qualified app name.
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
 {{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" .Values.global.namePrefix .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s-%s" .Values.global.namePrefix .Release.Name $name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/serverless-pdf-chat/values.schema.json
+++ b/charts/serverless-pdf-chat/values.schema.json
@@ -5,11 +5,14 @@
   "properties": {
     "global": {
       "type": "object",
+      "required": ["namePrefix"],
       "properties": {
         "namePrefix": {
           "type": "string",
-          "description": "Prefix for all resource names",
-          "default": "pdf-chat"
+          "description": "Unique prefix for all AWS resource names. Must be unique across all deployments in the AWS account.",
+          "minLength": 3,
+          "maxLength": 10,
+          "pattern": "^[a-z0-9-]+$"
         },
         "environment": {
           "type": "string",


### PR DESCRIPTION
## Changes
1. **AWS Resource Naming**
   - Modified fullname template to include namePrefix in resource names
   - Ensures uniqueness across AWS account deployments
   - Maintains backward compatibility with fullnameOverride
   - Prevents resource name contention in multi-deployment scenarios

2. **Providerconfigs Schema Fix**
   - Remove additionalProperties: false to allow global configuration injection
   - Fix helm installation failure caused by global value injection
   - Allow providerconfigs chart to accept global values from parent chart

## Why
- AWS resource names need to be unique across deployments to prevent conflicts
- Replicated injects global configuration into values during installation, which was being blocked by strict schema validation

## Testing
- Verify AWS resource names are unique across deployments
- Confirm helm installation succeeds with Replicated's global value injection
- Test deployment with different namePrefix values