### PR TITLE
Reworks image build to create pre-OCI images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECTDIR := $(shell pwd)
+PROJECTDIR := .
 
 # Set default parallelism
 MAKEFLAGS += -j$(shell nproc)
@@ -44,6 +44,14 @@ MAJOR_VERSION := $(shell echo $(DOCKER_TAG) | cut -d. -f1)
 MINOR_VERSION := $(shell echo $(DOCKER_TAG) | cut -d. -f1,2)
 DOCKERDIR := $(PROJECTDIR)/docker
 DOCKER_IMAGES := $(shell find $(DOCKERDIR) -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+
+# Disable attestations globally
+export BUILDX_NO_DEFAULT_ATTESTATIONS=1
+export BUILDKIT_NO_CLIENT_TOKEN=1
+export DOCKER_BUILDKIT_ATTESTATIONS=false
+
+# Force Docker manifest format (not OCI)
+export BUILDKIT_OUTPUT_OCI_MEDIATYPES=false
 
 # Group all .PHONY targets
 .PHONY: charts manifests images ecr-login clean lint release 
@@ -108,6 +116,7 @@ image-build-$1: create-ecr-repo-$1
 			-f $(DOCKERDIR)/$1/Dockerfile $(DOCKERDIR)/$1, \
 		$(DOCKER_CMD) build \
 			--platform linux/arm64 \
+      --progress plain \
 			--label org.opencontainers.image.source="$(GIT_HTTPS_URL)" \
 			--label org.opencontainers.image.revision="$(GIT_REVISION)" \
 			--label org.opencontainers.image.version="$(DOCKER_TAG)" \

--- a/docker/generate-embeddings/Dockerfile
+++ b/docker/generate-embeddings/Dockerfile
@@ -5,7 +5,7 @@ RUN python -c "import sys; print('Python search path:')" && \
     python -c "import sys; [print(p) for p in sys.path]"
 
 # Install git, swig, and other build dependencies
-RUN yum install -y git swig gcc-c++ make && \
+RUN yum install -y git swig gcc gcc-c++ make && \
     # Install packages directly to Lambda task root to ensure they're in the Python path
     pip install aws-lambda-powertools boto3 -t ${LAMBDA_TASK_ROOT} && \
     # Install pre-built faiss-cpu wheel for Python 3.11
@@ -16,7 +16,10 @@ RUN yum install -y git swig gcc-c++ make && \
     git clone https://github.com/aws-samples/serverless-pdf-chat.git /tmp/repo && \
     cp -r /tmp/repo/backend/src/generate_embeddings/* ${LAMBDA_TASK_ROOT}/ && \
     # Install any additional requirements
-    if [ -f "${LAMBDA_TASK_ROOT}/requirements.txt" ]; then pip install -r ${LAMBDA_TASK_ROOT}/requirements.txt -t ${LAMBDA_TASK_ROOT}; fi && \
+    if [ -f "${LAMBDA_TASK_ROOT}/requirements.txt" ]; then \
+      echo "numpy==1.24.3" >> ${LAMBDA_TASK_ROOT}/requirements.txt \
+      pip install -r ${LAMBDA_TASK_ROOT}/requirements.txt -t ${LAMBDA_TASK_ROOT}; \
+    fi && \
     # Clean up
     yum remove -y git gcc-c++ make && yum clean all && \
     rm -rf /tmp/repo

--- a/docker/generate-response/Dockerfile
+++ b/docker/generate-response/Dockerfile
@@ -5,16 +5,19 @@ RUN python -c "import sys; print('Python search path:')" && \
     python -c "import sys; [print(p) for p in sys.path]"
 
 # Install git and required packages directly to Lambda task root
-RUN yum install -y git && \
+RUN yum install -y gcc gcc-c++ swig make git && \
     # Install packages directly to Lambda task root to ensure they're in the Python path
     pip install aws-lambda-powertools boto3 -t ${LAMBDA_TASK_ROOT} && \
     # Clone the repo and copy function code
     git clone https://github.com/aws-samples/serverless-pdf-chat.git /tmp/repo && \
     cp -r /tmp/repo/backend/src/generate_response/* ${LAMBDA_TASK_ROOT}/ && \
     # Install any additional requirements
-    if [ -f "${LAMBDA_TASK_ROOT}/requirements.txt" ]; then pip install -r ${LAMBDA_TASK_ROOT}/requirements.txt -t ${LAMBDA_TASK_ROOT}; fi && \
+    if [ -f "${LAMBDA_TASK_ROOT}/requirements.txt" ]; then \
+      echo "numpy==1.24.3" >> ${LAMBDA_TASK_ROOT}/requirements.txt \
+      pip install -r ${LAMBDA_TASK_ROOT}/requirements.txt -t ${LAMBDA_TASK_ROOT}; \
+    fi && \
     # Clean up
-    yum remove -y git && yum clean all && \
+    yum remove -y gcc gcc-c++ make git && yum clean all && \
     rm -rf /tmp/repo
 
 # Copy our patched main.py to the Lambda task root


### PR DESCRIPTION
TL;DR
-----

Explicitly builds iamges as Docker images rather tha OCI images

Details
-------

Updates image build to build legacy Docker images rather than OCI
images. Apparently Lambda does not support proper OCI images, and
somewhere along the way our tooling seems to have shifted so that we
were building/pushing OCI images and not the older legacy format.

Builds are now explicitly configured through environemnt varuiables to
create legacy Docker images.

The issues we had also surfaced that our two images with dependencies
on NumpPy would not build properly with the lates version of NumPy.
The most likely cause for that was a lack of pre-built binaries for
the latest version on ARM64 Linux. Resolves this issue by pinning a
directy depenedncy to NumPy and using that version in the transistive
dependency chain.
